### PR TITLE
Fix interpolation jitter

### DIFF
--- a/src/game/interpolator.cpp
+++ b/src/game/interpolator.cpp
@@ -98,17 +98,13 @@ void PlayerInterpolator::tick(float dt) {
     for (auto& [playerId, player] : players) {
         if (player.totalFrames < 2) continue;
 
-        float realFrameDelta = player.newerFrame.timestamp - player.olderFrame.timestamp;
-        // this makes absolutely no sense im fucking fuming right now
-        // why the fuck does a static non-changing number work better than an actual calculation
-        float fakeFrameDelta = settings.expectedDelta;
-        if (realFrameDelta == 0.f) {
+        float frameDelta = player.newerFrame.timestamp - player.olderFrame.timestamp;
+        if (frameDelta == 0.f) {
             LerpLogger::get().logLerpSkip(playerId, this->getLocalTs(), player.timeCounter, player.interpolatedState.player1);
             continue;
         }
 
-        float lerpRatio = (player.timeCounter - player.olderFrame.timestamp) / fakeFrameDelta;
-
+        float lerpRatio = (player.timeCounter - player.olderFrame.timestamp) / frameDelta;
         lerpPlayer(player.olderFrame.visual, player.newerFrame.visual, player.interpolatedState, lerpRatio);
 
         LerpLogger::get().logLerpOperation(playerId, this->getLocalTs(), player.timeCounter, player.interpolatedState.player1);

--- a/src/hooks/play_layer.cpp
+++ b/src/hooks/play_layer.cpp
@@ -27,15 +27,6 @@ constexpr float PROXIMITY_VOICE_LIMIT = 1200.f;
 constexpr float VOICE_OVERLAY_PAD_X = 5.f;
 constexpr float VOICE_OVERLAY_PAD_Y = 20.f;
 
-float adjustLerpTimeDelta(float dt) {
-    // TODO: fix vsync
-    auto* dir = CCDirector::get();
-    return dir->getAnimationInterval();
-
-    // uncomment and watch the world blow up
-    // return dt;
-}
-
 /* Hooks */
 
 bool GlobedPlayLayer::init(GJGameLevel* level, bool p1, bool p2) {
@@ -591,7 +582,11 @@ void GlobedPlayLayer::selPeriodicalUpdate(float) {
 }
 
 // selUpdate - runs every frame, increments the non-decreasing time counter, interpolates and updates players
-void GlobedPlayLayer::selUpdate(float rawdt) {
+void GlobedPlayLayer::selUpdate(float timescaledDt) {
+    // timescale silently changing dt isn't very good when doing network interpolation >_>
+    // since timeCounter needs to agree with everyone else on how long a second is!
+    float dt = timescaledDt / CCScheduler::get()->getTimeScale();
+
     auto self = static_cast<GlobedPlayLayer*>(PlayLayer::get());
 
     if (!self) return;
@@ -611,7 +606,6 @@ void GlobedPlayLayer::selUpdate(float rawdt) {
         static_cast<uint32_t>(self->m_level->isPlatformer() ? self->m_level->m_bestTime : self->m_level->m_normalPercent)
     );
 
-    float dt = adjustLerpTimeDelta(rawdt);
     self->m_fields->timeCounter += dt;
 
     self->m_fields->interpolator->tick(dt);


### PR DESCRIPTION
Delta time is your friend!!! Btw, there should basically never be a reason to use the target FPS for anything, considering the case where the client can't run the game at that target speed, making it irrelevant. (plus the target FPS isn't even always accurately reported anyway).