### PR TITLE
Change the image used for DRPC

### DIFF
--- a/src/hooks/gjbasegamelayer.cpp
+++ b/src/hooks/gjbasegamelayer.cpp
@@ -741,7 +741,7 @@ void GlobedGJBGL::updateDRPC() {
         {"smallImageText", ""},
         {"useTime", true},
         {"shouldResetTime", false},
-        {"largeImageKey", "https://github.com/HJfod/globed-site/blob/main/public/logo.png?raw=true"},
+        {"largeImageKey", "https://raw.githubusercontent.com/dankmeme01/globed2/main/logo.png"},
         {"largeImageText", ""},
         {"joinSecret", std::to_string(m_level->m_levelID.value())},
         {"partyMax", m_fields->players.size() + 1}


### PR DESCRIPTION
Changed the image so that light mode users (basically non-existent) can see the logo better